### PR TITLE
MAINT: Store volume properties in DAV like CommonMetadata does, not in the XML body

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ zeit.content.volume changes
 1.3.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Store volume properties in DAV like CommonMetadata does, not in the
+  XML body (unclear why that ever was different).
 
 
 1.3.0 (2016-12-29)

--- a/src/zeit/content/volume/browser/tests/test_toc.py
+++ b/src/zeit/content/volume/browser/tests/test_toc.py
@@ -1,23 +1,19 @@
 # -*- coding: utf-8 -*-
-import sys
-import mock
-from ordereddict import OrderedDict
 from collections import defaultdict
-
-import lxml.etree
-
-import zope.component
-
-import zeit.cms.content.sources
-import zeit.cms.content.add
+from ordereddict import OrderedDict
 from zeit.cms.repository.folder import Folder
-import zeit.cms.testing
-import zeit.connector.mock
 from zeit.content.article.testing import create_article
-import zeit.content.volume.interfaces
 from zeit.content.volume.browser.toc import Toc, Excluder
 from zeit.content.volume.volume import Volume
+import lxml.etree
+import mock
+import sys
+import zeit.cms.content.add
+import zeit.cms.content.sources
+import zeit.cms.testing
+import zeit.content.volume.interfaces
 import zeit.content.volume.testing
+import zope.component
 
 
 class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
@@ -62,7 +58,7 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
 
     def test_list_relevant_ressort_folders_excludes_leserbriefe_and_images(
             self):
-        toc = Toc(None, None)
+        toc = Toc(mock.Mock(), mock.Mock())
         toc_connector = zope.component.getUtility(
             zeit.content.volume.interfaces.ITocConnector)
         self.zca.patch_utility(toc_connector,
@@ -88,7 +84,7 @@ class TocFunctionalTest(zeit.content.volume.testing.FunctionalTestCase):
                     'teaser': 'Das soll der Teaser sein',
                     'author': 'Autor'}
         article_element = lxml.etree.fromstring(article_xml)
-        toc = Toc(None, None)
+        toc = Toc(mock.Mock(), mock.Mock())
         result = toc._create_toc_element(article_element)
         self.assertEqual(expected, result)
 
@@ -101,7 +97,7 @@ Dossier\r
 1\tAutor\ttitle tease\r
 3\tAutor\ttitle2 tease\r
 """
-        toc = Toc(None, None)
+        toc = Toc(mock.Mock(), mock.Mock())
         res = toc._create_csv(self.toc_data)
         self.assertEqual(expected, res)
 
@@ -111,13 +107,13 @@ Dossier\r
         ressort, article_list = ressort_dict.iteritems().next()
         article_list[0]['author'] = ''
         input_data = {product: {ressort: article_list}}
-        toc = Toc(None, None)
+        toc = Toc(mock.Mock(), mock.Mock())
         assert toc.CSV_DELIMITER*2 in toc._create_csv(input_data)
 
     def test_empty_page_node_in_xml_results_in_max_int_page_in_toc_entry(self):
         article_xml = self.article_xml_template.format(page='')
         article_element = lxml.etree.fromstring(article_xml)
-        t = Toc(None, None)
+        t = Toc(mock.Mock(), mock.Mock())
         entry = t._create_toc_element(article_element)
         assert sys.maxint == entry.get('page')
 
@@ -136,7 +132,7 @@ Dossier\r
             }
         }
         toc_data = OrderedDict(toc_data)
-        t = Toc(None, None)
+        t = Toc(mock.Mock(), mock.Mock())
         result = t._sort_toc_data(toc_data)
         assert sys.maxint == result.get('Die Zeit').get('Politik')[-1].get(
             'page')
@@ -167,7 +163,7 @@ Dossier\r
             zeit.connector.interfaces.IConnector)
         # register_archive_connector is called in __init__
         # check for the correct side effects
-        t = Toc(None, None)
+        t = Toc(mock.Mock(), mock.Mock())
         new_connector = zope.component.getUtility(
             zeit.connector.interfaces.IConnector)
         # Check if a new IConnector was registered

--- a/src/zeit/content/volume/browser/toc.py
+++ b/src/zeit/content/volume/browser/toc.py
@@ -9,7 +9,6 @@ from ordereddict import OrderedDict
 
 import zeit.cms.browser.view
 from zeit.cms.i18n import MessageFactory as _
-import zeit.cms.content.sources
 import zeit.cms.interfaces
 from zeit.cms.repository.interfaces import IFolder
 import zeit.connector.connector
@@ -19,8 +18,6 @@ from zeit.content.volume.interfaces import ITocConnector, PRODUCT_MAPPING
 
 import zope.app.appsetup.product
 import zope.component
-import zope.component.registry
-import zope.interface
 import zope.site.site
 
 
@@ -42,8 +39,8 @@ class Toc(zeit.cms.browser.view.Base):
         self.dav_archive_url = config.get('dav-archive-url')
         self.dav_archive_url_parsed = urlparse.urlparse(self.dav_archive_url)
         self.excluder = Excluder()
-        self._register_archive_connector()
         self.connector = zope.component.getUtility(ITocConnector)
+        self._register_archive_connector()
 
     def _register_archive_connector(self):
         """
@@ -61,8 +58,7 @@ class Toc(zeit.cms.browser.view.Base):
         # This would make the new registry persistent.
         default_registry.removeSub(registry)
         site.setSiteManager(registry)
-        connector = zope.component.getUtility(ITocConnector)
-        registry.registerUtility(connector, IConnector)
+        registry.registerUtility(self.connector, IConnector)
         zope.component.hooks.setSite(site)
 
     def __call__(self):

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -29,18 +29,10 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
         </volume>
     """
 
-    year = zeit.cms.content.property.ObjectPathProperty(
-        '.body.year', zeit.content.volume.interfaces.IVolume['year'])
-    volume = zeit.cms.content.property.ObjectPathProperty(
-        '.body.volume', zeit.content.volume.interfaces.IVolume['volume'])
-    teaserText = zeit.cms.content.property.ObjectPathProperty(
-        '.body.teaserText',
-        zeit.content.volume.interfaces.IVolume['teaserText'])
-
     zeit.cms.content.dav.mapProperties(
         zeit.content.volume.interfaces.IVolume,
         zeit.cms.interfaces.DOCUMENT_SCHEMA_NS,
-        ('date_digital_published',))
+        ('date_digital_published', 'year', 'volume', 'teaserText'))
 
     _product_id = zeit.cms.content.dav.DAVProperty(
         zope.schema.TextLine(),


### PR DESCRIPTION
- Consistency with CommonMetadata; it's unclear why we ever did this differently for Volume
- zeit.publisher:update_solr expects those values in that place