### PR TITLE
ZON-3533: Support dependent products

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.volume changes
 1.3.3 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- ZON-3533: Support dependent products
 
 
 1.3.2 (2017-01-12)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'pytz',
         'setuptools',
         'zc.sourcefactory',
-        'zeit.cms >= 2.92.0.dev0',
+        'zeit.cms >= 2.95.0.dev0',
         'zeit.content.article >= 3.21.1.dev0',
         'zeit.content.cp',
         'zeit.content.image',

--- a/src/zeit/content/volume/browser/tests/test_form.py
+++ b/src/zeit/content/volume/browser/tests/test_form.py
@@ -66,7 +66,7 @@ class VolumeBrowserTest(zeit.cms.testing.BrowserTestCase):
         b = self.browser
         self.open_add_form()
         b.getControl('Year').value = '2010'
-        b.getControl('Volume').value = '2'
+        b.getControl(name='form.volume').value = '2'
         b.getControl('Add').click()
         content = ExampleContentType()
         content.year = 2010
@@ -91,7 +91,7 @@ __return(cp)"""
         self.open_add_form()
         b = self.browser
         b.getControl('Year').value = '2010'
-        b.getControl('Volume').value = '2'
+        b.getControl(name='form.volume').value = '2'
         b.getControl('Add').click()
         with zeit.cms.testing.site(self.getRootFolder()):
             cp = zeit.cms.interfaces.ICMSContent(

--- a/src/zeit/content/volume/interfaces.py
+++ b/src/zeit/content/volume/interfaces.py
@@ -26,7 +26,7 @@ class ProductSource(zeit.cms.content.sources.ProductSource):
             if value.relates_to:
                 dependent_products[value.relates_to] += [value]
         for product in products:
-            product.dependent_products = dependent_products.get(product.id)
+            product.dependent_products = dependent_products[product.id]
         return products
 
 PRODUCT_SOURCE = ProductSource()

--- a/src/zeit/content/volume/interfaces.py
+++ b/src/zeit/content/volume/interfaces.py
@@ -18,16 +18,7 @@ class ProductSource(zeit.cms.content.sources.ProductSource):
 
     def getValues(self, context):
         values = super(ProductSource, self).getValues(context)
-        products = []
-        dependent_products = defaultdict(list)
-        for value in values:
-            if value.volume:
-                products.append(value)
-            if value.relates_to:
-                dependent_products[value.relates_to] += [value]
-        for product in products:
-            product.dependent_products = dependent_products[product.id]
-        return products
+        return [value for value in values if value.volume]
 
 PRODUCT_SOURCE = ProductSource()
 

--- a/src/zeit/content/volume/tests/test_interfaces.py
+++ b/src/zeit/content/volume/tests/test_interfaces.py
@@ -4,18 +4,8 @@ import zeit.content.volume.interfaces
 
 class TestProductSource(zeit.content.volume.testing.FunctionalTestCase):
 
-    def setUp(self):
-        source = zeit.content.volume.interfaces.PRODUCT_SOURCE
-        self.values = list(source(None))
-
     def test_source_is_filtered_by_volume_attribute(self):
-        self.assertEqual(2, len(self.values))
-        self.assertEqual('Die Zeit', self.values[0].title)
-
-    def test_zeit_has_zeit_magazin_as_dependent_products(self):
-        self.assertEqual('Zeit Magazin', self.values[0].dependent_products[
-            0].title)
-
-    def test_source_without_dependencies_has_empty_list_as_dependent_products(
-            self):
-        self.assertEqual([], self.values[1].dependent_products)
+        source = zeit.content.volume.interfaces.PRODUCT_SOURCE
+        values = list(source(None))
+        self.assertEqual(2, len(values))
+        self.assertEqual('Die Zeit', values[0].title)

--- a/src/zeit/content/volume/tests/test_interfaces.py
+++ b/src/zeit/content/volume/tests/test_interfaces.py
@@ -1,11 +1,17 @@
 import zeit.content.volume.testing
+import zeit.content.volume.interfaces
 
 
 class TestProductSource(zeit.content.volume.testing.FunctionalTestCase):
 
+    def setUp(self):
+        self.source = zeit.content.volume.interfaces.PRODUCT_SOURCE
+
     def test_source_is_filtered_by_volume_attribute(self):
-        from zeit.content.volume.interfaces import ProductSource
-        source = ProductSource()
-        values = list(source(None))
+        values = list(self.source(None))
         self.assertEqual(1, len(values))
         self.assertEqual('Die Zeit', values[0].title)
+
+    def test_zeit_has_zeit_magazin_as_dependent_products(self):
+        values = list(self.source(None))
+        self.assertEqual('Zeit Magazin', values[0].dependent_products[0].title)

--- a/src/zeit/content/volume/tests/test_interfaces.py
+++ b/src/zeit/content/volume/tests/test_interfaces.py
@@ -5,13 +5,17 @@ import zeit.content.volume.interfaces
 class TestProductSource(zeit.content.volume.testing.FunctionalTestCase):
 
     def setUp(self):
-        self.source = zeit.content.volume.interfaces.PRODUCT_SOURCE
+        source = zeit.content.volume.interfaces.PRODUCT_SOURCE
+        self.values = list(source(None))
 
     def test_source_is_filtered_by_volume_attribute(self):
-        values = list(self.source(None))
-        self.assertEqual(1, len(values))
-        self.assertEqual('Die Zeit', values[0].title)
+        self.assertEqual(2, len(self.values))
+        self.assertEqual('Die Zeit', self.values[0].title)
 
     def test_zeit_has_zeit_magazin_as_dependent_products(self):
-        values = list(self.source(None))
-        self.assertEqual('Zeit Magazin', values[0].dependent_products[0].title)
+        self.assertEqual('Zeit Magazin', self.values[0].dependent_products[
+            0].title)
+
+    def test_source_without_dependencies_has_empty_list_as_dependent_products(
+            self):
+        self.assertEqual([], self.values[1].dependent_products)

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -87,6 +87,28 @@ class TestReference(zeit.content.volume.testing.FunctionalTestCase):
         with self.assertRaises(TypeError):
             zeit.content.volume.interfaces.IVolume(content)
 
+    def test_contents_with_defined_dependency_adapt_to_same_volume(self):
+        zei_content = ExampleContentType()
+        zei_content.year = 2015
+        zei_content.volume = 1
+        zei_content.product = zeit.cms.content.sources.Product(u'ZEI')
+        zmlb_content = ExampleContentType()
+        zmlb_content.year = 2015
+        zmlb_content.volume = 1
+        zmlb_content.product = zeit.cms.content.sources.Product(u'ZMLB')
+        self.assertEqual(zeit.content.volume.interfaces.IVolume(zei_content),
+                         zeit.content.volume.interfaces.IVolume(zmlb_content))
+
+    def test_cant_adapt_content_with_dependency_defined_to_a_non_volume(
+            self):
+        zecw_content = ExampleContentType()
+        zecw_content.year = 2015
+        zecw_content.volume = 1
+        zecw_content.product = zeit.cms.content.sources.Product(
+            u'BADDEPENDENCY')
+        with self.assertRaises(TypeError):
+            zeit.content.volume.interfaces.IVolume(zecw_content)
+
 
 class TestVolume(zeit.content.volume.testing.FunctionalTestCase):
 

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -123,7 +123,8 @@ class TestVolume(zeit.content.volume.testing.FunctionalTestCase):
         self.repository['2015']['01']['ausgabe'] = volume
 
     def test_looks_up_centerpage_from_product_setting(self):
-        self.repository['2015']['01']['index'] = zeit.content.cp.centerpage.CenterPage()
+        self.repository['2015']['01']['index'] = zeit.content.cp.centerpage\
+            .CenterPage()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2015/01/ausgabe')
         cp = zeit.content.cp.interfaces.ICenterPage(volume)

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -123,7 +123,7 @@ class TestVolume(zeit.content.volume.testing.FunctionalTestCase):
         self.repository['2015']['01']['ausgabe'] = volume
 
     def test_looks_up_centerpage_from_product_setting(self):
-        self.repository['2015']['01']['index'] = zeit.content.cp.centerpage\
+        self.repository['2015']['01']['index'] = zeit.content.cp.centerpage \
             .CenterPage()
         volume = zeit.cms.interfaces.ICMSContent(
             'http://xml.zeit.de/2015/01/ausgabe')
@@ -136,6 +136,17 @@ class TestVolume(zeit.content.volume.testing.FunctionalTestCase):
             'http://xml.zeit.de/2015/01/ausgabe')
         cp = zeit.content.cp.interfaces.ICenterPage(volume, None)
         self.assertEqual(None, cp)
+
+    def test_looks_up_centerpage_for_depent_product_content(self):
+        content = ExampleContentType()
+        content.product = zeit.cms.content.sources.Product(u'ZMLB')
+        self.repository['2015']['01']['index'] = content
+        volume = zeit.cms.interfaces.ICMSContent(
+            'http://xml.zeit.de/2015/01/ausgabe')
+        self.repository['2015']['01']['index'] = zeit.content.cp.centerpage \
+            .CenterPage()
+        cp = zeit.content.cp.interfaces.ICenterPage(volume)
+        self.assertEqual('http://xml.zeit.de/2015/01/index', cp.uniqueId)
 
 
 class TestOrder(zeit.content.volume.testing.FunctionalTestCase):

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -184,9 +184,11 @@ def retrieve_volume_using_info_from_metadata(context):
     elif context.product.volume and context.product.location:
         unique_id = Volume._fill_template(context, context.product.location)
     else:
-        for product in zeit.content.volume.interfaces.PRODUCT_SOURCE(None):
-            if context.product in product.dependent_products:
-                unique_id = Volume._fill_template(context, product.location)
+        main_product = zeit.content.volume.interfaces.PRODUCT_SOURCE(
+            context).find(context.product.relates_to)
+        if main_product and main_product.volume:
+                unique_id = Volume._fill_template(context,
+                                                  main_product.location)
     return zeit.cms.interfaces.ICMSContent(unique_id, None)
 
 

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -195,9 +195,17 @@ def retrieve_volume_using_info_from_metadata(context):
 @grok.adapter(zeit.content.volume.interfaces.IVolume)
 @grok.implementer(zeit.content.cp.interfaces.ICenterPage)
 def retrieve_corresponding_centerpage(context):
-    if context.product is None or context.product.centerpage is None:
+    unique_id = None
+    if context.product is None:
         return None
-    unique_id = context.fill_template(context.product.centerpage)
+    elif context.product.location:
+        unique_id = context.fill_template(context.product.centerpage)
+    else:
+        # Check if the main_product references the centerpage
+        main_product = zeit.content.volume.interfaces.PRODUCT_SOURCE(
+            context).find(context.product.relates_to)
+        if main_product and main_product.centerpage:
+            unique_id = context.fill_template(main_product.centerpage)
     cp = zeit.cms.interfaces.ICMSContent(unique_id, None)
     if not zeit.content.cp.interfaces.ICenterPage.providedBy(cp):
         return None

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -177,21 +177,17 @@ class VolumeCovers(
 @grok.adapter(zeit.cms.content.interfaces.ICommonMetadata)
 @grok.implementer(zeit.content.volume.interfaces.IVolume)
 def retrieve_volume_using_info_from_metadata(context):
+    unique_id = None
     if (context.year is None or context.volume is None or
-                context.product is None):
-        return None
+            context.product is None):
+        pass
     elif context.product.volume and context.product.location:
-        uniqueId = Volume._fill_template(context, context.product.location)
-        return zeit.cms.interfaces.ICMSContent(uniqueId, None)
+        unique_id = Volume._fill_template(context, context.product.location)
     else:
-        for product in zeit.content.volume.interfaces.PRODUCT_SOURCE:
+        for product in zeit.content.volume.interfaces.PRODUCT_SOURCE(None):
             if context.product in product.dependent_products:
-                uniqueId = Volume._fill_template(context,
-                                                 context.product.location)
-                return zeit.cms.interfaces.ICMSContent(uniqueId, None)
-        return None
-
-
+                unique_id = Volume._fill_template(context, product.location)
+    return zeit.cms.interfaces.ICMSContent(unique_id, None)
 
 
 @grok.adapter(zeit.content.volume.interfaces.IVolume)
@@ -199,8 +195,8 @@ def retrieve_volume_using_info_from_metadata(context):
 def retrieve_corresponding_centerpage(context):
     if context.product is None or context.product.centerpage is None:
         return None
-    uniqueId = context.fill_template(context.product.centerpage)
-    cp = zeit.cms.interfaces.ICMSContent(uniqueId, None)
+    unique_id = context.fill_template(context.product.centerpage)
+    cp = zeit.cms.interfaces.ICMSContent(unique_id, None)
     if not zeit.content.cp.interfaces.ICenterPage.providedBy(cp):
         return None
     return cp

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -178,11 +178,20 @@ class VolumeCovers(
 @grok.implementer(zeit.content.volume.interfaces.IVolume)
 def retrieve_volume_using_info_from_metadata(context):
     if (context.year is None or context.volume is None or
-            context.product is None or not context.product.volume or
-            context.product.location is None):
+                context.product is None):
         return None
-    uniqueId = Volume._fill_template(context, context.product.location)
-    return zeit.cms.interfaces.ICMSContent(uniqueId, None)
+    elif context.product.volume and context.product.location:
+        uniqueId = Volume._fill_template(context, context.product.location)
+        return zeit.cms.interfaces.ICMSContent(uniqueId, None)
+    else:
+        for product in zeit.content.volume.interfaces.PRODUCT_SOURCE:
+            if context.product in product.dependent_products:
+                uniqueId = Volume._fill_template(context,
+                                                 context.product.location)
+                return zeit.cms.interfaces.ICMSContent(uniqueId, None)
+        return None
+
+
 
 
 @grok.adapter(zeit.content.volume.interfaces.IVolume)

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -177,31 +177,31 @@ class VolumeCovers(
 @grok.adapter(zeit.cms.content.interfaces.ICommonMetadata)
 @grok.implementer(zeit.content.volume.interfaces.IVolume)
 def retrieve_volume_using_info_from_metadata(context):
-    unique_id = None
     if (context.year is None or context.volume is None or
             context.product is None):
-        pass
-    elif context.product.volume and context.product.location:
+        return None
+
+    unique_id = None
+    if context.product.volume and context.product.location:
         unique_id = Volume._fill_template(context, context.product.location)
     else:
         main_product = zeit.content.volume.interfaces.PRODUCT_SOURCE(
             context).find(context.product.relates_to)
-        if main_product and main_product.volume:
-                unique_id = Volume._fill_template(context,
-                                                  main_product.location)
+        if main_product and main_product.volume and main_product.location:
+            unique_id = Volume._fill_template(context, main_product.location)
     return zeit.cms.interfaces.ICMSContent(unique_id, None)
 
 
 @grok.adapter(zeit.content.volume.interfaces.IVolume)
 @grok.implementer(zeit.content.cp.interfaces.ICenterPage)
 def retrieve_corresponding_centerpage(context):
-    unique_id = None
     if context.product is None:
         return None
-    elif context.product.location:
+
+    unique_id = None
+    if context.product.location:
         unique_id = context.fill_template(context.product.centerpage)
     else:
-        # Check if the main_product references the centerpage
         main_product = zeit.content.volume.interfaces.PRODUCT_SOURCE(
             context).find(context.product.relates_to)
         if main_product and main_product.centerpage:


### PR DESCRIPTION
ZON-3533: volume-objects can have mulitple products 
Depends on https://github.com/ZeitOnline/zeit.cms/pull/38