### PR TITLE
BUG-633: Make teaserText overridable on volume reference

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,8 @@ zeit.content.volume changes
 
 - ZON-3535: Covers per product
 
+- BUG-633: Make teaserText overridable on volume reference
+
 
 1.3.2 (2017-01-12)
 ------------------

--- a/src/zeit/content/volume/reference.py
+++ b/src/zeit/content/volume/reference.py
@@ -26,4 +26,9 @@ class RelatedReference(zeit.cms.content.reference.Reference):
     grok.implements(zeit.content.volume.interfaces.IVolumeReference)
     grok.name('related')
 
-    teaserText = zeit.cms.content.property.ObjectPathProperty('.teaserText')
+    _teaserText_local = zeit.cms.content.property.ObjectPathAttributeProperty(
+        '.', 'teasertext_local',
+        zeit.content.volume.interfaces.IVolumeReference['teaserText'])
+    teaserText = zeit.cms.content.reference.OverridableProperty(
+        zeit.content.volume.interfaces.IVolume['teaserText'],
+        original='target')

--- a/src/zeit/content/volume/tests/test_reference.py
+++ b/src/zeit/content/volume/tests/test_reference.py
@@ -1,6 +1,7 @@
 import lxml.objectify
 import zeit.cms.content.interfaces
 import zeit.content.article.edit.volume
+import zeit.content.cp.centerpage
 import zeit.content.volume.testing
 import zope.component
 
@@ -16,12 +17,32 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
         self.volume = self.repository['testvolume']
 
     def test_volume_can_be_adapted_to_IXMLReference(self):
-        result = zope.component.getAdapter(
+        reference = zope.component.getAdapter(
             self.volume,
             zeit.cms.content.interfaces.IXMLReference,
             name='related')
-        self.assertEqual('volume', result.tag)
-        self.assertEqual(self.volume.uniqueId, result.get('href'))
+        self.assertEqual('volume', reference.tag)
+        self.assertEqual(self.volume.uniqueId, reference.get('href'))
+
+    def test_reference_honors_ICommonMetadata_xml_format(self):
+        from zeit.content.volume.volume import Volume
+        from zeit.cms.repository.folder import Folder
+        volume = Volume()
+        volume.year = 2015
+        volume.volume = 1
+        volume.teaserText = 'original'
+        volume.product = zeit.cms.content.sources.Product(u'ZEI')
+        self.repository['2015'] = Folder()
+        self.repository['2015']['01'] = Folder()
+        self.repository['2015']['01']['ausgabe'] = volume
+        self.repository['2015']['01'][
+            'index'] = zeit.content.cp.centerpage.CenterPage()
+
+        reference = zope.component.getAdapter(
+            volume,
+            zeit.cms.content.interfaces.IXMLReference,
+            name='related')
+        self.assertEqual(volume.teaserText, reference.description)
 
     def test_volume_can_be_adapted_to_IReference(self):
         from zeit.content.volume.interfaces import IVolumeReference

--- a/src/zeit/content/volume/tests/test_reference.py
+++ b/src/zeit/content/volume/tests/test_reference.py
@@ -1,3 +1,4 @@
+import lxml.objectify
 import zeit.cms.content.interfaces
 import zeit.content.article.edit.volume
 import zeit.content.volume.testing
@@ -9,11 +10,8 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
     def setUp(self):
         from zeit.content.volume.volume import Volume
         super(VolumeReferenceTest, self).setUp()
-
         self.repository['testvolume'] = Volume()
         self.volume = self.repository['testvolume']
-        self.reference_container = zeit.content.article.edit.volume.Volume(
-            self.volume, self.volume.xml)
 
     def test_volume_can_be_adapted_to_IXMLReference(self):
         result = zope.component.getAdapter(
@@ -26,11 +24,16 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
     def test_volume_can_be_adapted_to_IReference(self):
         from zeit.content.volume.interfaces import IVolumeReference
 
-        result = zope.component.getMultiAdapter(
-            (self.reference_container, self.volume.xml),
+        node = zope.component.getAdapter(
+            self.volume, zeit.cms.content.interfaces.IXMLReference,
+            name='related')
+        source = zeit.content.article.edit.volume.Volume(
+            None, lxml.objectify.XML('<volume/>'))
+        reference = zope.component.getMultiAdapter(
+            (source, node),
             zeit.cms.content.interfaces.IReference, name='related')
 
-        result.teaserText = 'Test teaser'
+        reference.teaserText = 'Test teaser'
 
-        self.assertEqual(True, IVolumeReference.providedBy(result))
-        self.assertEqual('Test teaser', result.xml.teaserText.text)
+        self.assertEqual(True, IVolumeReference.providedBy(reference))
+        self.assertEqual('Test teaser', reference.xml.teaserText.text)

--- a/src/zeit/content/volume/tests/test_reference.py
+++ b/src/zeit/content/volume/tests/test_reference.py
@@ -68,3 +68,5 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
         self.assertEqual('original', reference.teaserText)
         reference.teaserText = u'local'
         self.assertEqual('local', reference.teaserText)
+        reference.teaserText = None
+        self.assertEqual('original', reference.teaserText)

--- a/src/zeit/content/volume/tests/test_reference.py
+++ b/src/zeit/content/volume/tests/test_reference.py
@@ -10,7 +10,9 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
     def setUp(self):
         from zeit.content.volume.volume import Volume
         super(VolumeReferenceTest, self).setUp()
-        self.repository['testvolume'] = Volume()
+        volume = Volume()
+        volume.teaserText = 'original'
+        self.repository['testvolume'] = volume
         self.volume = self.repository['testvolume']
 
     def test_volume_can_be_adapted_to_IXMLReference(self):
@@ -23,7 +25,6 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
 
     def test_volume_can_be_adapted_to_IReference(self):
         from zeit.content.volume.interfaces import IVolumeReference
-
         node = zope.component.getAdapter(
             self.volume, zeit.cms.content.interfaces.IXMLReference,
             name='related')
@@ -32,8 +33,17 @@ class VolumeReferenceTest(zeit.content.volume.testing.FunctionalTestCase):
         reference = zope.component.getMultiAdapter(
             (source, node),
             zeit.cms.content.interfaces.IReference, name='related')
-
-        reference.teaserText = 'Test teaser'
-
         self.assertEqual(True, IVolumeReference.providedBy(reference))
-        self.assertEqual('Test teaser', reference.xml.teaserText.text)
+
+    def test_teasertext_can_be_overridden(self):
+        node = zope.component.getAdapter(
+            self.volume, zeit.cms.content.interfaces.IXMLReference,
+            name='related')
+        source = zeit.content.article.edit.volume.Volume(
+            None, lxml.objectify.XML('<volume/>'))
+        reference = zope.component.getMultiAdapter(
+            (source, node),
+            zeit.cms.content.interfaces.IReference, name='related')
+        self.assertEqual('original', reference.teaserText)
+        reference.teaserText = u'local'
+        self.assertEqual('local', reference.teaserText)

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -139,6 +139,25 @@ class VolumeType(zeit.cms.type.XMLContentTypeDeclaration):
     type = 'volume'
 
 
+class VolumeMetadata(grok.Adapter):
+    """Since ICenterPage inherits from ICommonMetadata, we need to ensure
+    that adapting a volume to ICommonMetadata returns fields from the volume,
+    and not the CP.
+    """
+
+    grok.context(zeit.content.volume.interfaces.IVolume)
+    grok.implements(zeit.cms.content.interfaces.ICommonMetadata)
+
+    missing = object()
+
+    def __getattr__(self, name):
+        value = getattr(self.context, name, self.missing)
+        if value is self.missing:
+            field = zeit.cms.content.interfaces.ICommonMetadata.get(name, None)
+            return field.default
+        return value
+
+
 @grok.adapter(zeit.cms.content.interfaces.ICommonMetadata)
 @grok.implementer(zeit.content.volume.interfaces.IVolume)
 def retrieve_volume_using_info_from_metadata(context):


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.cms/pull/39

Wenn abgenommen+released, im friedbert-deployment eintragen