### PR TITLE
BUG-711 Wrong volume reference in article

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.volume changes
 1.7.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-711: Friedbert preview doesn't render article with wrong volume reference
 
 
 1.7.0 (2017-04-12)

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -56,9 +56,13 @@ class TestVolumeCovers(zeit.content.volume.testing.FunctionalTestCase):
             '<covers xmlns:py="http://codespeak.net/lxml/objectify/pytype"/>',
             lxml.etree.tostring(self.volume.xml.covers))
 
-    def test_raises_if_product_is_not_in_volume(self):
+    def test_raises_value_error_if_invalid_product_id_used_in_set_cover(self):
         with self.assertRaises(ValueError):
-            self.assertEqual(None, self.volume.get_cover('ipad', 'TEST'))
+            self.volume.set_cover('ipad', 'TEST', self.repository[
+                'imagegroup'])
+
+    def test_returns_none_if_invalid_product_id_used_in_get_cover(self):
+        self.assertEqual(None, self.volume.get_cover('ipad', 'TEST'))
 
     def test_resolves_given_product_id(self):
         self.add_ipad_cover('ZMLB')

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -119,8 +119,9 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
             product_id = self.product.id
         if product_id and product_id not in \
                 [prod.id for prod in self._all_products]:
-            raise ValueError('%s is not a valid product id for %s' % (
+            log.warning('%s is not a valid product id for %s' % (
                 product_id, self))
+            return None
         path = '//covers/cover[@id="{}" and @product_id="{}"]' \
             .format(cover_id, product_id)
         node = self.xml.xpath(path)
@@ -130,6 +131,7 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
         if use_fallback:
             # Fall back to the main product (which must be self.product,
             # since we respond only to ids out of self._all_products)
+            # Recursive call of this function with the main product ID
             return self.get_cover(
                 cover_id, self.product.id, use_fallback=False)
 


### PR DESCRIPTION
Remove ValueError being raised in get_cover of volume.

If an invalid product id is passed as a paremeter get_cover now returns None
instead of raising a value error. Friedbert will then render a reference with
a fallback cover and not nothing at all. In addition to this change a new validation
rule is added to the cp-validation rules, which raises an error if a wrong
volume is referenced in an article and warns the user in the UI.

Validation Rule to add:

`applicable('article' in globals() and article and
           __import__('zeit.content.article.edit.interfaces', fromlist=['IVolume']).IVolume.providedBy(context))
import zeit.content.volume.interfaces
error_if(context.references.target != zeit.content.volume.interfaces.IVolume(context.__parent__.__parent__, None),
           u'Das Ausgabenobjekt gehört nicht zu der Ausgabe dieses Artikels oder die Produkt-ID dieses Artikels ist keiner Ausgabe zugewiesen.')
`