### PR TITLE
BUG-757: Store multi publish errors in volume object objectlog

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.volume changes
 1.8.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- BUG-757: Store multi publish errors in volume object objectlog
 
 
 1.8.0 (2017-08-07)

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         'pytz',
         'setuptools',
         'zc.sourcefactory',
-        'zeit.cms >= 2.107.0.dev0',
+        'zeit.cms >= 2.108.0.dev0',
         'zeit.content.article >= 3.23.0.dev0',
         'zeit.content.cp',
         'zeit.content.image',

--- a/src/zeit/content/volume/browser/publish-all.pt
+++ b/src/zeit/content/volume/browser/publish-all.pt
@@ -2,7 +2,8 @@
 <h1 i18n:translate="">Publish</h1>
 
 <ol id="worklist">
-  <li action="start_job" cms:param="publish-all" i18n:translate="">Publishing volume content</li>
+  <!-- param: action, param2: objectlog -->
+  <li action="start_job" cms:param="publish-all" cms:param2="True" i18n:translate="">Publishing volume content</li>
   <li action="reload" i18n:translate="">Reloading</li>
 </ol>
 

--- a/src/zeit/content/volume/browser/tests/test_admin.py
+++ b/src/zeit/content/volume/browser/tests/test_admin.py
@@ -152,3 +152,16 @@ class PublishAllContent(zeit.cms.testing.SeleniumTestCase,
         s.waitForElementNotPresent('css=li.busy[action=start_job]')
         s.assertElementNotPresent('id=publish.errors')
         s.waitForPageToLoad()
+
+    def test_multi_publish_errors_are_logged_on_volume(self):
+        s = self.selenium
+        self.open('/repository/ausgabe/@@admin.html', self.login_as)
+        with mock.patch(
+                'zeit.workflow.publish.MultiPublishTask.recurse') as recurse:
+            recurse.side_effect = RuntimeError('provoked')
+            s.click('id=form.actions.publish-all')
+            s.waitForElementPresent('css=li.busy[action=start_job]')
+            s.waitForElementNotPresent('css=li.busy[action=start_job]')
+            s.waitForPageToLoad()
+        s.click('css=li.workflow')
+        s.assertText('css=.fieldname-logs .widget', '*provoked*')


### PR DESCRIPTION
Needs https://github.com/ZeitOnline/zeit.cms/pull/69