### PR TITLE
MAINT: Make number of empty columns in toc configurable

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,7 @@ zeit.content.volume changes
 1.9.1 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- MAINT: Make number of empty columns for toc configurable
 
 
 1.9.0 (2017-10-04)

--- a/src/zeit/content/volume/browser/toc.py
+++ b/src/zeit/content/volume/browser/toc.py
@@ -334,7 +334,12 @@ class Toc(zeit.cms.browser.view.Base):
         page = toc_entry.get('page')
         if page == sys.maxint:
             page = ''
-        return [str(page), title_teaser, '', '', '', toc_entry.get('access')]
+        config = zope.app.appsetup.product.getProductConfiguration(
+            'zeit.content.volume')
+        number_of_empty_columns = int(config.get('toc-num-empty-columns', 2))
+        return [str(page), title_teaser] + \
+               [''] * number_of_empty_columns +  \
+               [toc_entry.get('access')]
 
 
 class Excluder(object):
@@ -342,7 +347,7 @@ class Excluder(object):
     Checks if an article should be excluded from the table of contents.
     """
     # Rules should be as strict as possible,
-    # otherwise the wrong article might get  excluded
+    # otherwise the wrong article might get excluded
     TITLE_XPATH = "body/title/text()"
     SUPERTITLE_XPATH = "body/supertitle/text()"
     JOBNAME_XPATH = "//attribute[@name='jobname']/text()"

--- a/src/zeit/content/volume/testing.py
+++ b/src/zeit/content/volume/testing.py
@@ -13,6 +13,7 @@ product_config = """
     volume-cover-source file://{here}/tests/fixtures/volume-covers.xml
     dav-archive-url test
     toc-product-ids ZEI BAD
+    toc-num-empty-columns 3
     default-teaser-text Teäser {{name}}/{{year}}
 </product-config>
 """.format(here=pkg_resources.resource_filename(__name__, '.'))


### PR DESCRIPTION
This way we don't have to make a z.c.volume release each time this changes.
We still need a deployment though.
If this should get merged,  i will add the correct setting in vivi-deployment :guardsman: