### PR TITLE
ZON-4938: Dont change access for performing articles

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -2,10 +2,10 @@ zeit.content.volume changes
 ===========================
 
 
-1.10.1 (unreleased)
+1.11.0 (unreleased)
 -------------------
 
-- ZON-4938:  Add option to pass extra constraint when changing access for volume
+- ZON-4938: Don't change access for performing articles
 
 
 1.10.0 (2018-08-20)

--- a/src/zeit/content/volume/interfaces.py
+++ b/src/zeit/content/volume/interfaces.py
@@ -94,7 +94,8 @@ class IVolume(zeit.cms.content.interfaces.IXMLContent):
         wont be published by this method.
         :param access_from: access value to replace
         :param access_to: new acces value
-        :param published: bool to specify if only published content should
+        :param published: bool to specify if only published content should be
+               changed
         :param exclude_performing_articles: exclude performing articles from
                change
         :param dry_run: don't actually change the access value

--- a/src/zeit/content/volume/interfaces.py
+++ b/src/zeit/content/volume/interfaces.py
@@ -86,7 +86,8 @@ class IVolume(zeit.cms.content.interfaces.IXMLContent):
         :return: [ICMSContent]
         """
 
-    def change_contents_access(access_from, access_to, published):
+    def change_contents_access(access_from, access_to, published,
+                               exclude_performing_articles, dry_run):
         """
         Change the access value, from access_from to access_to, for all
         content of this volume and returns the content. The changed content
@@ -94,7 +95,9 @@ class IVolume(zeit.cms.content.interfaces.IXMLContent):
         :param access_from: access value to replace
         :param access_to: new acces value
         :param published: bool to specify if only published content should
-        be changed
+        :param exclude_performing_articles: exclude performing articles from
+               change
+        :param dry_run: don't actually change the access value
         :return: [CMSContent, ...]
         """
 

--- a/src/zeit/content/volume/interfaces.py
+++ b/src/zeit/content/volume/interfaces.py
@@ -171,7 +171,7 @@ PRODUCT_MAPPING = ProductNameMapper()
 class AccessControlConfig(zeit.cms.content.sources.CachedXMLBase):
 
     product_configuration = 'zeit.content.volume'
-    config_url = 'volume-access-control-config'
+    config_url = 'access-control-config'
 
     @property
     def min_cr(self):

--- a/src/zeit/content/volume/testing.py
+++ b/src/zeit/content/volume/testing.py
@@ -15,12 +15,12 @@ product_config = """
     toc-product-ids ZEI BAD
     toc-num-empty-columns 3
     default-teaser-text Teäser {{name}}/{{year}}
-    access-control-config
-    access-control-webtrekk-url
-    access-control-webtrekk-timeout
-    access-control-webtrekk-username
-    access-control-webtrekk-password
-    access-control-webtrekk-customerId
+    access-control-config file://{here}/tests/fixtures/access-control.xml
+    access-control-webtrekk-url https://webtrekkapi.foo
+    access-control-webtrekk-timeout 10
+    access-control-webtrekk-username foo
+    access-control-webtrekk-password bar
+    access-control-webtrekk-customerId 123
 </product-config>
 """.format(here=pkg_resources.resource_filename(__name__, '.'))
 

--- a/src/zeit/content/volume/testing.py
+++ b/src/zeit/content/volume/testing.py
@@ -15,6 +15,12 @@ product_config = """
     toc-product-ids ZEI BAD
     toc-num-empty-columns 3
     default-teaser-text Teäser {{name}}/{{year}}
+    access-control-config
+    access-control-webtrekk-url
+    access-control-webtrekk-timeout
+    access-control-webtrekk-username
+    access-control-webtrekk-password
+    access-control-webtrekk-customerId
 </product-config>
 """.format(here=pkg_resources.resource_filename(__name__, '.'))
 

--- a/src/zeit/content/volume/tests/fixtures/access-control.xml
+++ b/src/zeit/content/volume/tests/fixtures/access-control.xml
@@ -1,0 +1,4 @@
+<config>
+  <min_cr>0.1</min_cr>
+  <min_orders>5</min_orders>
+</config>

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -3,8 +3,7 @@ from datetime import datetime
 from zeit.cms.repository.folder import Folder
 from zeit.cms.testcontenttype.testcontenttype import ExampleContentType
 from zeit.content.image.testing import create_image_group
-from zeit.content.volume.volume import (
-    Volume, _find_performing_articles_via_webtrekk)
+from zeit.content.volume.volume import Volume
 import lxml.etree
 import lxml.objectify
 import mock
@@ -342,7 +341,8 @@ class TestWebtrekkQuery(TestVolumeQueries):
             ['web..trekk|www.zeit.de/2019/01/baz', 1, 0.01]     # None of above
         ]
         with self.webtrekk(webtrekk_data) as m:
-            res = _find_performing_articles_via_webtrekk(self.volume)
+            res = zeit.content.volume.volume.\
+                _find_performing_articles_via_webtrekk(self.volume)
             self.assertEqual(['2019/01/foo', '2019/01/bar', '2019/01/foobar'],
                              res)
 
@@ -352,6 +352,7 @@ class TestWebtrekkQuery(TestVolumeQueries):
             ['web..trekk|www.zeit.de/2019/02/bar', 10, 0.2]
         ]
         with self.webtrekk(webtrekk_data) as m:
-            res = _find_performing_articles_via_webtrekk(self.volume)
+            res = zeit.content.volume.volume.\
+                _find_performing_articles_via_webtrekk(self.volume)
             self.assertEqual(['2019/01/foo', ],
                              res)

--- a/src/zeit/content/volume/tests/test_volume.py
+++ b/src/zeit/content/volume/tests/test_volume.py
@@ -283,7 +283,9 @@ class TestVolumeQueries(zeit.content.volume.testing.FunctionalTestCase):
         for c in cnt:
             self.assertEqual('free', c.access)
 
-        volume.change_contents_access('free', 'abo')
-
+        with mock.patch('zeit.content.volume.volume.'
+                        '_find_performing_articles_via_webtrekk') as pa:
+            pa.return_value = []
+            volume.change_contents_access('free', 'abo')
         for c in cnt:
             self.assertEqual('abo', c.access)

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -395,7 +395,7 @@ def _find_performing_articles_via_webtrekk(volume):
     this should only be used when performance is no criteria.
     """
     api_date_format = '%Y-%m-%d %H:%M:%S'
-    cr_metric_name = u'CR Bestellungen Abo (Artikelbasis)',
+    cr_metric_name = u'CR Bestellungen Abo (Artikelbasis)'
     order_metric_name = u'Anzahl Bestellungen \u2013\xa0Zplus (Seitenbasis)'
     config = zope.app.appsetup.product.getProductConfiguration(
         'zeit.content.volume')
@@ -410,6 +410,7 @@ def _find_performing_articles_via_webtrekk(volume):
                 'login': config['access-control-webtrekk-username'],
                 'pass': config['access-control-webtrekk-password'],
                 'customerId': config['access-control-webtrekk-customerid'],
+                'language': 'de',
                 'analysisConfig': {
                     "analysisFilter": {'filterRules': [
                         # Only paid articles

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -432,10 +432,15 @@ def _find_performing_articles_via_webtrekk(volume):
     access_control_config = (
         zeit.content.volume.interfaces.ACCESS_CONTROL_CONFIG)
     resp = requests.post(config['access-control-webtrekk-url'],
-                         timeout=config['access-control-webtrekk-timeout'],
+                         timeout=int(
+                             config['access-control-webtrekk-timeout']),
                          json=body)
+    result = resp.json()
+    if result.get('error'):
+        raise Exception('Webtrekk API reported an error %s' %
+                        result.get('error'))
+    data = result['result']['analysisData']
     urls = set()
-    data = resp.json()['result']['analysisData']
     for page, order, cr in data:
         url = page.split('zeit.de/')[1]
         if url.startswith(volume.fill_template('{year}/{name}')) and \

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -226,7 +226,12 @@ class Volume(zeit.cms.content.xmlsupport.XMLContentBase):
             exclude_performing_articles=True, dry_run=False):
         constraints = [{'term': {'payload.document.access': access_from}}]
         if exclude_performing_articles:
-            to_filter = _find_performing_articles_via_webtrekk(self)
+            try:
+                to_filter = _find_performing_articles_via_webtrekk(self)
+            except Exception:
+                log.error("Error while retrieving data from webtrekk api",
+                          exc_info=True)
+                return []
             log.info("Not changing access for %s " % to_filter)
             filter_constraint = {
                 'bool': {'must_not': {'terms': {'url': to_filter}}}}

--- a/src/zeit/content/volume/volume.py
+++ b/src/zeit/content/volume/volume.py
@@ -407,9 +407,9 @@ def _find_performing_articles_via_webtrekk(volume):
     body = {'version': '1.1',
             'method': 'getAnalysisData',
             'params': {
-                'login': config['access_control_webtrekk_username'],
-                'pass': config['access_control_webtrekk_password'],
-                'customerId': config['access_control_webtrekk_customerId'],
+                'login': config['access-control-webtrekk-username'],
+                'pass': config['access-control-webtrekk-password'],
+                'customerId': config['access-control-webtrekk-customerid'],
                 'analysisConfig': {
                     "analysisFilter": {'filterRules': [
                         # Only paid articles
@@ -430,8 +430,8 @@ def _find_performing_articles_via_webtrekk(volume):
 
     access_control_config = (
         zeit.content.volume.interfaces.ACCESS_CONTROL_CONFIG)
-    resp = requests.post(config['access_control_webtrekk_url'],
-                         timeout=config['access_control_webtrekk_timeout'],
+    resp = requests.post(config['access-control-webtrekk-url'],
+                         timeout=config['access-control-webtrekk-timeout'],
                          json=body)
     urls = set()
     data = resp.json()['result']['analysisData']


### PR DESCRIPTION
This PR moves code  [as requested here](https://github.com/ZeitOnline/vivi-deployment/pull/63) to z.c.volume.
